### PR TITLE
Fix for benchmark names that include spaces

### DIFF
--- a/cloben.hs
+++ b/cloben.hs
@@ -261,7 +261,7 @@ criterionBenchmarks =
 
       word :: Pattern Text
       word =
-        plus (satisfy (not . isSpace))
+        plus (satisfy (/= '\n'))
 
       decimalPlaces :: Rational -> Rational
       decimalPlaces n =


### PR DESCRIPTION
Currently, the parser for Criterion output doesn't handle benchmark names that include spaces.  This is one (unsophisticated but nonetheless seems-to-work) way to fix that.